### PR TITLE
(fix) stop deleting payload keys if not declared in schema when using {strict:false}

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ module.exports = class Schemy {
 	 * @param {Boolean} orderBody Order the body based on the schema
 	 * @returns {Object} Last validated data
 	 */
-	getBody(includeAll = false, orderBody = true) {
+	getBody(includeAll = true, orderBody = true) {
 		let output = { ...this.data };
 		let ordered = {};
 

--- a/spec/methods.spec.js
+++ b/spec/methods.spec.js
@@ -69,7 +69,7 @@ describe('Schemy methods', function() {
 		const input = {title: 'something', age: 21};
 
 		expect(schema.validate(input)).toBe(true);
-		expect(schema.getBody()).toEqual({title: 'something'});
+		expect(schema.getBody()).toEqual({title: 'something', age: 21});
 	});
 
 	it('Should throw error if passing not Schemy instance as validation argument', async function() {


### PR DESCRIPTION
Stop deleting payload keys if are not declared in schema when using `{strict:false}`