### PR TITLE
Fix bug where validations were always strict inside nested array schemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,8 +93,20 @@ module.exports = class Schemy {
 								const { custom } = schema[key];
 								parsed.custom = custom;
 							}
-	
-							parsed.type = new Schemy(properties);
+							
+							let flex = false;
+							let _props = properties;
+
+							//? Inherit flex property from the array latest children, so [Schemy] won't be always strict
+							while (Array.isArray(_props)) {
+								_props = _props[0];
+							}
+
+							if (_props.flex !== undefined) flex = _props.flex;
+							else if(_props.type && _props.type.flex !== undefined) flex = _props.type.flex;
+							else flex = false;
+
+							parsed.type = new Schemy(properties, { strict: !flex });
 							parsed.required = !!properties.required;
 	
 							schema[key] = parsed;


### PR DESCRIPTION
Cases like the following, where an array schema is inside another, the "flex" property is not inherited properly, and result in a strict 1 element array, where [ '0' ] is the only allowed property, discarding valid multi-element arrays

```js
const Schemy = require('schemy');


const fooSchemy = new Schemy({ id: { type: String, required: false } },{ strict: false })

const barsSchemy = new Schemy(
    {
      foos: [
        {
          type: fooSchemy,
          required: true,
        },
      ],
    },
    { strict: false }
)
const schema = new Schemy({
    bars: {
      type: [barsSchemy],
      required: true,
    }
});

// Prints true (OK)
console.log(schema.validate({
    "bars":[{
        "foos":[{"id": "xxxxx" }]
    }]
}))

// Prints false (Unexpected behavior)
console.log(schema.validate({
    "bars":[{
        "foos":[
            { "id": "xxxxx" },
            { "id": "xxxxx" }
        ]
    }]
}))
```

What i propose is to inherit the strictness from the last children before creating the children schema